### PR TITLE
Explicitly specify packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setup(
     package_dir={
         f"{HOST_MLIR_PYTHON_PACKAGE_PREFIX}.extras": "mlir/extras",
     },
+    packages={f"{HOST_MLIR_PYTHON_PACKAGE_PREFIX}.extras"},
 )


### PR DESCRIPTION
Some versions of distutils seem to need this to be explicitly specified.