### PR TITLE
Do not require scalar for memref set value

### DIFF
--- a/mlir/extras/dialects/ext/memref.py
+++ b/mlir/extras/dialects/ext/memref.py
@@ -175,6 +175,7 @@ class MemRef(Value, ShapedValue):
             if isinstance(val, (int, float)):
                 # TODO: this is an unchecked conversion
                 val = Scalar(val, dtype=self.dtype)
+            assert isinstance(val, Scalar), "coordinate insert requires scalar element"
             store(val, self, idx, loc=loc)
         else:
             _copy_to_subview(self, val, tuple(idx), loc=loc)

--- a/mlir/extras/dialects/ext/memref.py
+++ b/mlir/extras/dialects/ext/memref.py
@@ -172,7 +172,9 @@ class MemRef(Value, ShapedValue):
                 idx[i] = constant(d, index=True, loc=loc)
 
         if all(isinstance(d, Scalar) for d in idx) and len(idx) == len(self.shape):
-            assert isinstance(val, Scalar), "coordinate insert requires scalar element"
+            if isinstance(val, (int, float)):
+                # TODO: this is an unchecked conversion
+                val = Scalar(val, dtype=self.dtype)
             store(val, self, idx, loc=loc)
         else:
             _copy_to_subview(self, val, tuple(idx), loc=loc)


### PR DESCRIPTION
Hello! 

I'm not sure if this fits entirely with the `mlir-python-extras` philosophy (and I'm not sure how to test `mlir-python-extras` beyond how I am using it), but a local modification I made was to infer the type of an inserted element into a `MemRef` based on the `dtype` of `MemRef`. While this does allow one to shoot themselves in the foot more easily, it does make some of the resulting code in my examples look a bit cleaner as I'm trying to avoid using the `constant()` function if the `dtype` can be reasonably inferred some other way.

As a side note, if this PR is accepted, I believe `mlir-aie` has a clear path forward for using `mlir-python-extras` as an external library (https://github.com/Xilinx/mlir-aie/pull/1828). We would be using the commit at `main`, so AFAIK the `aie` branch is no longer needed.

The reason I am attempting to upstream this particular change, and why I feel it is an important step in using `mlir-python-extras` as a library, is because using the `mlir-python-extras` `memref` module is more or less an all-or-nothing endeavor because the following can only be called once:
```
@register_value_caster(MemRefType.static_typeid)
```

So I can't use other pieces of the `mlir-python-extras` `memref` module while overriding a small portion of the `memref` module myself locally. If this PR is not accepted, my options are to either:
* Keep my own copy of memref with my minor change
* Something else I haven't thought of?

Let me know your thoughts!