### PR TITLE
fix llvm tests

### DIFF
--- a/tests/test_llvm.py
+++ b/tests/test_llvm.py
@@ -8,13 +8,16 @@ from mlir.extras.dialects.ext.func import func
 
 # noinspection PyUnresolvedReferences
 from mlir.extras.testing import MLIRContext, filecheck, mlir_ctx as ctx
-from util import llvm_bindings_not_installed
+from util import llvm_bindings_not_installed, llvm_amdgcn_bindings_not_installed
 
 # needed since the fix isn't defined here nor conftest.py
 pytest.mark.usefixtures("ctx")
 
 
-@pytest.mark.skipif(llvm_bindings_not_installed(), reason="llvm bindings not installed")
+@pytest.mark.skipif(
+    llvm_bindings_not_installed() or llvm_amdgcn_bindings_not_installed(),
+    reason="llvm bindings not installed or llvm_amdgcn bindings not installed",
+)
 def test_call_instrinsic(ctx: MLIRContext):
     @func(emit=True)
     def sum(a: T.i32(), b: T.i32(), c: T.f32()):

--- a/tests/util.py
+++ b/tests/util.py
@@ -38,6 +38,18 @@ def llvm_bindings_not_installed():
         return True
 
 
+def llvm_amdgcn_bindings_not_installed():
+    try:
+        from mlir.extras.dialects.ext.llvm import amdgcn
+
+        # don't skip
+        return False
+
+    except ImportError:
+        # skip
+        return True
+
+
 def hip_check(call_result):
     from hip import hip
 


### PR DESCRIPTION
 (basically disable because i don't want to require installing eudsl-llvmpy during build)